### PR TITLE
Comment out skill ID in builder

### DIFF
--- a/src/com/amazon/ask/airplanefacts/AirplaneFactsStreamHandler.java
+++ b/src/com/amazon/ask/airplanefacts/AirplaneFactsStreamHandler.java
@@ -16,8 +16,8 @@ public class AirplaneFactsStreamHandler extends SkillStreamHandler {
                         new LaunchRequestHandler(),
                         new SessionEndedRequestHandler(),
                         new FallBackIntentHandler())
-                // Add your skill id below
-                .withSkillId("")
+                // Add your skill id below and uncomment to enable skill ID verification
+                // .withSkillId("")
                 .build();
     }
 


### PR DESCRIPTION
This causes confusion because an empty skill ID string is still checked against the incoming request, resulting in an exception.